### PR TITLE
fix duplicate fun parameter names

### DIFF
--- a/src/lexbor/lib/encoding.cr
+++ b/src/lexbor/lib/encoding.cr
@@ -75,8 +75,8 @@ module Lexbor
     fun decode_buf_used_set = lxb_encoding_decode_buf_used_set_noi(decode : DecodeT, used : LibC::SizeT)
     fun encode_buf_used_set = lxb_encoding_encode_buf_used_set_noi(encode : EncodeT, used : LibC::SizeT)
 
-    fun data_call_encode = lxb_encoding_data_call_encode_noi(data : DataT, ctx : EncodeT, cp : CodepointT**, end : CodepointT*) : Lib::StatusT
-    fun data_call_decode = lxb_encoding_data_call_decode_noi(data : DataT, ctx : DecodeT, data : UInt8**, end : UInt8*) : Lib::StatusT
+    fun data_call_encode = lxb_encoding_data_call_encode_noi(encoding_data : DataT, ctx : EncodeT, cp : CodepointT**, end : CodepointT*) : Lib::StatusT
+    fun data_call_decode = lxb_encoding_data_call_decode_noi(encoding_data : DataT, ctx : DecodeT, data : UInt8**, end : UInt8*) : Lib::StatusT
 
     fun encode_t_sizeof = lxb_encoding_encode_t_sizeof : LibC::SizeT
     fun decode_t_sizeof = lxb_encoding_decode_t_sizeof : LibC::SizeT


### PR DESCRIPTION
Fixes:

```
In src/lexbor/lib/encoding.cr:79:91

 79 | fun data_call_decode = lxb_encoding_data_call_decode_noi(data : DataT, ctx : DecodeT, data : UInt8**, end : UInt8*) : Lib::StatusT
                                                                                            ^
Error: duplicated fun parameter name: data
```

Relevant Crystal PR: https://github.com/crystal-lang/crystal/pull/11967

https://github.com/lexbor/lexbor/blob/5ffe6e63270aa3ff79e5f53506a0ba63a945a3b2/source/lexbor/encoding/encoding.h#L455-L459=