### PR TITLE
Minor version bump to support Crystal 1.5

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lexbor
-version: 3.0.3
+version: 3.0.4
 
 authors:
   - Konstantin Makarchev <kostya27@gmail.com>

--- a/src/lexbor.cr
+++ b/src/lexbor.cr
@@ -1,5 +1,5 @@
 module Lexbor
-  VERSION = "3.0.3"
+  VERSION = "3.0.4"
 
   def self.lib_version
   end


### PR DESCRIPTION
Crystal 1.5 now errors out with duplicate named kwargs from `fun`. This version bump is just meant to include the recent fix into a final version.