### PR TITLE
remove makefile dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ authors:
   - Konstantin Makarchev <kostya27@gmail.com>
 
 scripts:
-  postinstall: cd src/ext && make package
+  postinstall: crystal run src/ext/build_lexbor.cr
 
 crystal: ">= 0.35.1, < 2.0.0"
 license: MIT

--- a/src/ext/build_lexbor.cr
+++ b/src/ext/build_lexbor.cr
@@ -1,4 +1,4 @@
-REV = "fcff658c77199b81623178e5ab6be17d0d4e24c8"
+REV = "b0dc514cf81bb830aa1db4e273739436dd6597c9"
 
 def print_stdout_stderr(proc : Process)
   while (line = proc.output.gets) || (line = proc.error.gets)

--- a/src/ext/build_lexbor.cr
+++ b/src/ext/build_lexbor.cr
@@ -1,5 +1,10 @@
 REV = "b0dc514cf81bb830aa1db4e273739436dd6597c9"
 
+def static_link_thread_windows(args : Array(String))
+  args << "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW"
+  args << "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded"
+end
+
 def print_stdout_stderr(proc : Process)
   while (line = proc.output.gets) || (line = proc.error.gets)
     puts line
@@ -20,7 +25,18 @@ Process.run("git", args: ["reset", "--hard", REV], chdir: lexbor_c_path.to_s) { 
 lexbor_build_path = lexbor_c_path / "build"
 Dir.mkdir(lexbor_build_path)
 
-cmake_args = ["..", "-DCMAKE_BUILD_TYPE=Release", "-DLEXBOR_BUILD_TESTS_CPP=OFF", "-DLEXBOR_INSTALL_HEADERS=OFF", "-DLEXBOR_BUILD_SHARED=OFF"]
+cmake_args = [
+  "..",
+  "-DCMAKE_BUILD_TYPE=Release",
+  "-DLEXBOR_BUILD_TESTS_CPP=OFF",
+  "-DLEXBOR_INSTALL_HEADERS=OFF",
+  "-DLEXBOR_BUILD_SHARED=OFF",
+]
+
+{% if flag?(:win32) %}
+static_link_thread_windows(cmake_args)
+{% end %}
+
 Process.run("cmake", args: cmake_args, chdir: lexbor_build_path.to_s) { |p| print_stdout_stderr(p) }
 
 # Build the library

--- a/src/ext/build_lexbor.cr
+++ b/src/ext/build_lexbor.cr
@@ -25,4 +25,4 @@ Process.run("cmake", args: cmake_args, chdir: lexbor_build_path.to_s) { |p| prin
 
 # Build the library
 
-Process.run("cmake", args: ["--build", "."], chdir: lexbor_build_path.to_s) { |p| print_stdout_stderr(p) }
+Process.run("cmake", args: ["--build", ".", "--config", "Release", "-j", System.cpu_count.to_s], chdir: lexbor_build_path.to_s) { |p| print_stdout_stderr(p) }

--- a/src/ext/build_lexbor.cr
+++ b/src/ext/build_lexbor.cr
@@ -15,15 +15,19 @@ current_path = Path[__FILE__]
 lexbor_c_path = (current_path.parent) / "lexbor-c"
 args = ["clone", "https://github.com/lexbor/lexbor.git", lexbor_c_path.to_s]
 
-# TODO: Check if the git clone fails.
-Process.run("git", args: args) { |p| print_stdout_stderr(p) }
+unless File.directory? lexbor_c_path
+  # TODO: Check if the git clone fails.
+  Process.run("git", args: args) { |p| print_stdout_stderr(p) }
+end
 
 # Checkout to the specific SHA
 Process.run("git", args: ["reset", "--hard", REV], chdir: lexbor_c_path.to_s) { |p| print_stdout_stderr(p) }
 
 # Make the build directory
 lexbor_build_path = lexbor_c_path / "build"
-Dir.mkdir(lexbor_build_path)
+unless File.directory? lexbor_build_path
+  Dir.mkdir(lexbor_build_path)
+end
 
 cmake_args = [
   "..",

--- a/src/ext/build_lexbor.cr
+++ b/src/ext/build_lexbor.cr
@@ -1,0 +1,28 @@
+REV = "fcff658c77199b81623178e5ab6be17d0d4e24c8"
+
+def print_stdout_stderr(proc : Process)
+  while (line = proc.output.gets) || (line = proc.error.gets)
+    puts line
+  end
+end
+
+current_path = Path[__FILE__]
+lexbor_c_path = (current_path.parent) / "lexbor-c"
+args = ["clone", "https://github.com/lexbor/lexbor.git", lexbor_c_path.to_s]
+
+# TODO: Check if the git clone fails.
+Process.run("git", args: args) { |p| print_stdout_stderr(p) }
+
+# Checkout to the specific SHA
+Process.run("git", args: ["reset", "--hard", REV], chdir: lexbor_c_path.to_s) { |p| print_stdout_stderr(p) }
+
+# Make the build directory
+lexbor_build_path = lexbor_c_path / "build"
+Dir.mkdir(lexbor_build_path)
+
+cmake_args = ["..", "-DCMAKE_BUILD_TYPE=Release", "-DLEXBOR_BUILD_TESTS_CPP=OFF", "-DLEXBOR_INSTALL_HEADERS=OFF", "-DLEXBOR_BUILD_SHARED=OFF"]
+Process.run("cmake", args: cmake_args, chdir: lexbor_build_path.to_s) { |p| print_stdout_stderr(p) }
+
+# Build the library
+
+Process.run("cmake", args: ["--build", "."], chdir: lexbor_build_path.to_s) { |p| print_stdout_stderr(p) }

--- a/src/lexbor/lib.cr
+++ b/src/lexbor/lib.cr
@@ -1,7 +1,11 @@
 require "./lib/constants"
 
 module Lexbor
+  {% if flag?(:win32) %}
+  @[Link(ldflags: "#{__DIR__}/../ext/lexbor-c/build/Release/lexbor_static.lib")]
+  {% else %}
   @[Link(ldflags: "#{__DIR__}/../ext/lexbor-c/build/liblexbor_static.a")]
+  {% end %}
   lib Lib
     type DocT = Void*
     type CollectionT = Void*


### PR DESCRIPTION
Since the long goal of Crystal is to be able to be used in Windows as well, I was thinking on porting the `make` dependency to be simply Crystal scripts.

From what I see, Crystal itself uses Crystal scripts as utils, it is convenient because it's a dependency that will be always satisfied if you well, want to use Crystal.

More tested is needed so that's why I'm doing this as a draft PR, but I'd like to know if this is something you'd be interested as well.