### PR TITLE
Escape div in comment

### DIFF
--- a/src/lexbor/node/serialization.cr
+++ b/src/lexbor/node/serialization.cr
@@ -159,7 +159,7 @@ struct Lexbor::Node
 
   #
   # Convert end of tag to string
-  #   ex: node.to_html_end # => "</div>"
+  #   ex: node.to_html_end # => "\</div>"
   def to_html_end
     String.build { |io| to_html_end(io) }
   end


### PR DESCRIPTION
Fix #25 

Crystal appears to not escape html in doc comments when generating documentation, so this is necessary (hopefully only for now).