### PR TITLE
add MsvcEnv.with_env command to enable Visual Studio Command Environment

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 3.1.2
 authors:
   - Konstantin Makarchev <kostya27@gmail.com>
 
-development_dependencies:
+dependencies:
   msvc_env:
     github: dsisnero/msvc_env
     version: ~> 0.7.1

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,11 @@ version: 3.1.2
 authors:
   - Konstantin Makarchev <kostya27@gmail.com>
 
+development_dependencies:
+  msvc_env:
+    github: dsisnero/msvc_env
+    version: ~> 0.7.1
+
 scripts:
   postinstall: crystal src/ext/build_ext.cr
 

--- a/src/ext/build_ext.cr
+++ b/src/ext/build_ext.cr
@@ -39,5 +39,14 @@ cmake_args = [
   cmake_args << "Unix Makefiles"
 {% end %}
 
+
+{% if flag?(:win32) %}
+require "msvc_env/env"
+MsvcEnv.with_env do
 cmd("cmake", cmake_args, lexbor_build_path)
 cmd("cmake", ["--build", ".", "--config", "Release", "-j", {System.cpu_count, 4}.min.to_s], lexbor_build_path)
+end
+{% else %}
+cmd("cmake", cmake_args, lexbor_build_path)
+cmd("cmake", ["--build", ".", "--config", "Release", "-j", {System.cpu_count, 4}.min.to_s], lexbor_build_path)
+{% end %}


### PR DESCRIPTION
This enables a Visual Studio Command Environment when run on windows so that "nmake" is on PATH