### PR TITLE
fix: switch non-opaque ptrs types to alias

### DIFF
--- a/src/lexbor/lib.cr
+++ b/src/lexbor/lib.cr
@@ -88,10 +88,9 @@ module Lexbor
       length : LibC::SizeT
     end
 
-    type StrT = Str*
+    alias StrT = Str*
     type HashT = Void*
 
-    # type TokenAttrT = Void*
     struct TokenAttr
       name_begin : UInt8*
       name_end : UInt8*
@@ -105,7 +104,7 @@ module Lexbor
       type : HtmlTokenAttrTypeT
     end
 
-    type TokenAttrT = TokenAttr*
+    alias TokenAttrT = TokenAttr*
 
     struct HtmlToken
       begin_ : UInt8*
@@ -120,7 +119,7 @@ module Lexbor
       type_ : HtmlTokenTypeT
     end
 
-    type HtmlTokenT = HtmlToken*
+    alias HtmlTokenT = HtmlToken*
     alias HtmlTokenizerTokenF = HtmlTokenizerT, HtmlTokenT, Void* -> HtmlTokenT
 
     fun html_tokenizer_create = lxb_html_tokenizer_create : HtmlTokenizerT


### PR DESCRIPTION
Based on this comment from https://github.com/crystal-lang/crystal/issues/14151#issuecomment-1883556841, changing these to aliases make a bit more sense in this context.
Also, at least until the Interpreter fixes this bug, this will also also it to work again.